### PR TITLE
Fix lossless_jpeg args index

### DIFF
--- a/Worker.py
+++ b/Worker.py
@@ -169,7 +169,7 @@ class Worker(QRunnable):
 
             if self.params["lossless"]:
                 args[0] = "-q 100"
-                args[3] = "--lossless_jpeg=1"   # JPG reconstruction
+                args[2] = "--lossless_jpeg=1"   # JPG reconstruction
 
             # For lossless best Effort is always 9
             if self.params["intelligent_effort"] and (self.params["quality"] == 100 or self.params["lossless"]):


### PR DESCRIPTION
I noticed from task manager `lossless_jpeg` was being passed twice to cjxl, with values 0 and 1.

Edit: Oops, didn't notice the contribution policy until now. Well, I'll leave this up anyway - up to you if you want to merge.